### PR TITLE
feat: v0.8.0 — batch DB writes, WAL TUI reader, security hardening, provider fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scopeon"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1756,7 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "scopeon-collector"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "scopeon-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "scopeon-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "scopeon-metrics"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "scopeon-core",
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "scopeon-tui"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ default = []
 # OTel OTLP export: planned for future scopeon-otel crate
 
 [dependencies]
-scopeon-core = { path = "crates/scopeon-core", version = "0.7.0" }
-scopeon-collector = { path = "crates/scopeon-collector", version = "0.7.0" }
-scopeon-mcp = { path = "crates/scopeon-mcp", version = "0.7.0" }
-scopeon-tui = { path = "crates/scopeon-tui", version = "0.7.0" }
+scopeon-core = { path = "crates/scopeon-core", version = "0.8.0" }
+scopeon-collector = { path = "crates/scopeon-collector", version = "0.8.0" }
+scopeon-mcp = { path = "crates/scopeon-mcp", version = "0.8.0" }
+scopeon-tui = { path = "crates/scopeon-tui", version = "0.8.0" }
 tokio = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
@@ -61,7 +61,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 tokio-stream = "0.1"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Scopeon Contributors"]

--- a/crates/scopeon-collector/src/parser.rs
+++ b/crates/scopeon-collector/src/parser.rs
@@ -68,6 +68,7 @@ pub struct ParseResult {
     pub tool_calls: Vec<ToolCall>,
     pub interaction_events: Vec<InteractionEvent>,
     pub new_offset: u64,
+    pub skipped_lines: usize,
 }
 
 /// Parse new lines from a JSONL file starting at `from_offset`.
@@ -87,6 +88,7 @@ pub fn parse_file_incremental(
     let mut interaction_events: Vec<InteractionEvent> = Vec::new();
     let mut turn_index: i64 = start_turn_index;
     let mut current_offset = from_offset;
+    let mut skipped_lines: usize = 0;
     // IS-A: track msg_id → index in `turns` to deduplicate streaming records
     // (Claude Code emits 2-4 records per assistant turn with increasing output_tokens)
     let mut seen_msg_ids: HashMap<String, usize> = HashMap::new();
@@ -318,6 +320,7 @@ pub fn parse_file_incremental(
             },
             Err(e) => {
                 debug!("Skipping unparseable line in {:?}: {}", file_path, e);
+                skipped_lines += 1;
             },
         }
 
@@ -330,6 +333,7 @@ pub fn parse_file_incremental(
         tool_calls,
         interaction_events,
         new_offset: current_offset,
+        skipped_lines,
     })
 }
 

--- a/crates/scopeon-collector/src/providers/aider.rs
+++ b/crates/scopeon-collector/src/providers/aider.rs
@@ -206,7 +206,7 @@ impl Provider for AiderProvider {
                 .ok()
                 .and_then(|m| m.modified().ok())
                 .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_millis() as i64)
+                .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
                 .unwrap_or(0),
         )?;
 

--- a/crates/scopeon-collector/src/providers/gemini.rs
+++ b/crates/scopeon-collector/src/providers/gemini.rs
@@ -258,7 +258,7 @@ impl Provider for GeminiCLIProvider {
                     .ok()
                     .and_then(|m| m.modified().ok())
                     .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                    .map(|d| d.as_millis() as i64)
+                    .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
                     .unwrap_or(0),
             );
         }

--- a/crates/scopeon-collector/src/providers/generic_openai.rs
+++ b/crates/scopeon-collector/src/providers/generic_openai.rs
@@ -122,7 +122,7 @@ fn scan_openai_file(file: &std::path::Path, db: &Database) -> Result<usize> {
     let mut last_ts = 0i64;
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
         .unwrap_or(0);
 
     for line in reader.lines() {

--- a/crates/scopeon-collector/src/watcher.rs
+++ b/crates/scopeon-collector/src/watcher.rs
@@ -31,7 +31,7 @@ pub fn process_file(file_path: &Path, db: &Database) -> Result<()> {
         .modified()
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_millis() as i64)
+        .map(|d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
         .unwrap_or(0);
 
     let from_offset = if stored_offset > file_size && current_mtime > stored_mtime {
@@ -69,11 +69,28 @@ pub fn process_file(file_path: &Path, db: &Database) -> Result<()> {
 
     let result = parse_file_incremental(file_path, from_offset, start_turn_index)?;
 
-    if let Some(ref session) = result.session {
-        db.upsert_session(session)?;
+    if result.skipped_lines > 0 {
+        warn!(
+            "{} unparseable line(s) skipped in {:?} — data may be incomplete",
+            result.skipped_lines, file_path
+        );
+    }
 
-        // Auto-tag session from tool-call patterns (falls back to branch prefix).
-        // Only applies a tag if no manual tag has been set and the session has tool calls.
+    // Atomically write session, turns, tool calls, interaction events, and offset
+    // in a single transaction — crash-safe.
+    db.commit_parse_result(
+        &path_str,
+        result.session.as_ref(),
+        &result.turns,
+        &result.tool_calls,
+        &result.interaction_events,
+        result.new_offset,
+        current_mtime,
+    )?;
+
+    // Auto-tag session from tool-call patterns (falls back to branch prefix).
+    // Only applies a tag if no manual tag has been set and the session has tool calls.
+    if let Some(ref session) = result.session {
         if db
             .get_session_tags(&session.id)
             .map(|t| t.is_empty())
@@ -92,15 +109,6 @@ pub fn process_file(file_path: &Path, db: &Database) -> Result<()> {
                 }
             }
         }
-    }
-    for turn in &result.turns {
-        db.upsert_turn(turn)?;
-    }
-    for tc in &result.tool_calls {
-        db.upsert_tool_call(tc)?;
-    }
-    for event in &result.interaction_events {
-        db.upsert_interaction_event(event)?;
     }
 
     // §7.3: After turns are inserted, update session.total_turns from the authoritative
@@ -149,9 +157,6 @@ pub fn process_file(file_path: &Path, db: &Database) -> Result<()> {
         let timestamps: Vec<i64> = result.turns.iter().map(|t| t.timestamp).collect();
         db.refresh_daily_rollup_for_timestamps(&timestamps)?;
     }
-
-    // Update file offset
-    db.set_file_offset(&path_str, result.new_offset, current_mtime)?;
 
     Ok(())
 }

--- a/crates/scopeon-core/src/db.rs
+++ b/crates/scopeon-core/src/db.rs
@@ -11,11 +11,6 @@ use crate::models::*;
 /// very short follow-up message than a genuine context compaction.
 pub const COMPACTION_MIN_PREV_TOKENS: i64 = 50_000;
 
-/// Fraction by which input tokens must fall relative to the previous turn to be
-/// classified as a compaction event (empirically, Claude's compaction reduces
-/// context by ~60–80 %; 50 % gives a comfortable margin below genuine drops).
-const COMPACTION_DROP_THRESHOLD: f64 = 0.50;
-
 static MIGRATIONS: &[&str] = &[
     // M0001 — initial schema
     "CREATE TABLE IF NOT EXISTS sessions (
@@ -977,44 +972,6 @@ impl Database {
     }
 
     /// Check whether a newly-inserted turn represents a compaction event by comparing
-    /// its input token count against the previous turn in the same session.
-    ///
-    /// A compaction is detected when:
-    /// - The previous turn had > 50 000 input tokens (avoids false positives).
-    /// - Input tokens dropped by more than 50% relative to the previous turn.
-    ///
-    /// Returns `true` if a compaction was detected (and the turn was marked).
-    pub fn check_compaction_at_turn(
-        &self,
-        turn_id: &str,
-        session_id: &str,
-        turn_index: i64,
-        current_input: i64,
-    ) -> Result<bool> {
-        let prev_input: Option<i64> = self
-            .conn
-            .query_row(
-                "SELECT input_tokens FROM turns
-                 WHERE session_id = ?1 AND turn_index < ?2
-                 ORDER BY turn_index DESC
-                 LIMIT 1",
-                params![session_id, turn_index],
-                |r| r.get(0),
-            )
-            .ok();
-        if let Some(prev) = prev_input {
-            let drop = prev - current_input;
-            if prev > COMPACTION_MIN_PREV_TOKENS
-                && drop > 0
-                && (drop as f64 / prev as f64) > COMPACTION_DROP_THRESHOLD
-            {
-                self.mark_turn_compaction(turn_id)?;
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
     /// Returns the `input_tokens` of the turn immediately before `turn_index`
     /// in the given session, or `None` if no prior turn exists.
     pub fn get_turn_input_before(&self, session_id: &str, turn_index: i64) -> Result<Option<i64>> {
@@ -1131,6 +1088,403 @@ impl Database {
         Ok(())
     }
 
+    // ── Batch upserts (single transaction) ──────────────────────────────────
+
+    pub fn upsert_turns_batch(&self, turns: &[Turn]) -> Result<()> {
+        if turns.is_empty() {
+            return Ok(());
+        }
+        // SAFETY: see reprice_all_in_transaction — same pattern; Database is always
+        // accessed through Arc<Mutex<Database>>, so at most one caller holds the mutex.
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO turns
+                    (id, session_id, turn_index, timestamp, duration_ms,
+                     input_tokens, cache_read_tokens, cache_write_tokens,
+                     cache_write_5m_tokens, cache_write_1h_tokens, output_tokens,
+                     thinking_tokens, mcp_call_count, mcp_input_token_est, text_output_tokens,
+                     model, service_tier, estimated_cost_usd)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)
+                 ON CONFLICT(id) DO UPDATE SET
+                     turn_index         = excluded.turn_index,
+                     timestamp          = excluded.timestamp,
+                     duration_ms        = excluded.duration_ms,
+                     input_tokens       = excluded.input_tokens,
+                     cache_read_tokens  = excluded.cache_read_tokens,
+                     cache_write_tokens = excluded.cache_write_tokens,
+                     cache_write_5m_tokens = excluded.cache_write_5m_tokens,
+                     cache_write_1h_tokens = excluded.cache_write_1h_tokens,
+                     output_tokens      = excluded.output_tokens,
+                     thinking_tokens    = excluded.thinking_tokens,
+                     mcp_call_count     = excluded.mcp_call_count,
+                     mcp_input_token_est = excluded.mcp_input_token_est,
+                     text_output_tokens = excluded.text_output_tokens,
+                     model              = excluded.model,
+                     service_tier       = excluded.service_tier,
+                     estimated_cost_usd = excluded.estimated_cost_usd
+                     -- is_compaction_event intentionally omitted: once set by the
+                     -- compaction detector it must not be overwritten by a re-parse.",
+            )?;
+            for turn in turns {
+                stmt.execute(params![
+                    turn.id,
+                    turn.session_id,
+                    turn.turn_index,
+                    turn.timestamp,
+                    turn.duration_ms,
+                    turn.input_tokens,
+                    turn.cache_read_tokens,
+                    turn.cache_write_tokens,
+                    turn.cache_write_5m_tokens,
+                    turn.cache_write_1h_tokens,
+                    turn.output_tokens,
+                    turn.thinking_tokens,
+                    turn.mcp_call_count,
+                    turn.mcp_input_token_est,
+                    turn.text_output_tokens,
+                    turn.model,
+                    turn.service_tier,
+                    turn.estimated_cost_usd,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn upsert_tool_calls_batch(&self, tool_calls: &[ToolCall]) -> Result<()> {
+        if tool_calls.is_empty() {
+            return Ok(());
+        }
+        // SAFETY: see reprice_all_in_transaction — same pattern.
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT OR IGNORE INTO tool_calls (id, turn_id, session_id, tool_name, input_size_chars, input_hash, timestamp)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7)",
+            )?;
+            for tc in tool_calls {
+                stmt.execute(params![
+                    tc.id,
+                    tc.turn_id,
+                    tc.session_id,
+                    tc.tool_name,
+                    tc.input_size_chars,
+                    tc.input_hash as i64,
+                    tc.timestamp,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn upsert_interaction_events_batch(&self, events: &[InteractionEvent]) -> Result<()> {
+        if events.is_empty() {
+            return Ok(());
+        }
+        // SAFETY: see reprice_all_in_transaction — same pattern.
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT INTO interaction_events (
+                    id, session_id, turn_id, task_run_id, correlation_id, parent_id, provider,
+                    timestamp, kind, phase, name, display_name, mcp_server, mcp_tool, hook_type,
+                    agent_type, execution_mode, model, status, success, input_size_chars,
+                    output_size_chars, prompt_size_chars, summary_size_chars, total_tokens,
+                    total_tool_calls, duration_ms, estimated_input_tokens, estimated_output_tokens,
+                    estimated_cost_usd, confidence
+                 ) VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17,
+                    ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31
+                 )
+                 ON CONFLICT(id) DO UPDATE SET
+                    turn_id = COALESCE(excluded.turn_id, interaction_events.turn_id),
+                    task_run_id = COALESCE(excluded.task_run_id, interaction_events.task_run_id),
+                    correlation_id = COALESCE(excluded.correlation_id, interaction_events.correlation_id),
+                    parent_id = COALESCE(excluded.parent_id, interaction_events.parent_id),
+                    provider = COALESCE(NULLIF(excluded.provider, ''), interaction_events.provider),
+                    timestamp = excluded.timestamp,
+                    kind = excluded.kind,
+                    phase = excluded.phase,
+                    name = excluded.name,
+                    display_name = COALESCE(excluded.display_name, interaction_events.display_name),
+                    mcp_server = COALESCE(excluded.mcp_server, interaction_events.mcp_server),
+                    mcp_tool = COALESCE(excluded.mcp_tool, interaction_events.mcp_tool),
+                    hook_type = COALESCE(excluded.hook_type, interaction_events.hook_type),
+                    agent_type = COALESCE(excluded.agent_type, interaction_events.agent_type),
+                    execution_mode = COALESCE(excluded.execution_mode, interaction_events.execution_mode),
+                    model = COALESCE(excluded.model, interaction_events.model),
+                    status = COALESCE(excluded.status, interaction_events.status),
+                    success = COALESCE(excluded.success, interaction_events.success),
+                    input_size_chars = excluded.input_size_chars,
+                    output_size_chars = excluded.output_size_chars,
+                    prompt_size_chars = excluded.prompt_size_chars,
+                    summary_size_chars = excluded.summary_size_chars,
+                    total_tokens = COALESCE(excluded.total_tokens, interaction_events.total_tokens),
+                    total_tool_calls = COALESCE(excluded.total_tool_calls, interaction_events.total_tool_calls),
+                    duration_ms = COALESCE(excluded.duration_ms, interaction_events.duration_ms),
+                    estimated_input_tokens = excluded.estimated_input_tokens,
+                    estimated_output_tokens = excluded.estimated_output_tokens,
+                    estimated_cost_usd = excluded.estimated_cost_usd,
+                    confidence = excluded.confidence",
+            )?;
+            for event in events {
+                stmt.execute(params![
+                    event.id,
+                    event.session_id,
+                    event.turn_id,
+                    event.task_run_id,
+                    event.correlation_id,
+                    event.parent_id,
+                    event.provider,
+                    event.timestamp,
+                    event.kind,
+                    event.phase,
+                    event.name,
+                    event.display_name,
+                    event.mcp_server,
+                    event.mcp_tool,
+                    event.hook_type,
+                    event.agent_type,
+                    event.execution_mode,
+                    event.model,
+                    event.status,
+                    event.success.map(|v| v as i32),
+                    event.input_size_chars,
+                    event.output_size_chars,
+                    event.prompt_size_chars,
+                    event.summary_size_chars,
+                    event.total_tokens,
+                    event.total_tool_calls,
+                    event.duration_ms,
+                    event.estimated_input_tokens,
+                    event.estimated_output_tokens,
+                    event.estimated_cost_usd,
+                    event.confidence,
+                ])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Atomically persist a full parse result: optional session upsert, all turns,
+    /// tool calls, interaction events, and the file-offset checkpoint.  Either
+    /// everything commits or nothing does — crash-safe.
+    ///
+    /// SAFETY: `unchecked_transaction` is used instead of `transaction` because
+    /// `self.conn` is behind `&self` (not `&mut self`). Nested transactions are
+    /// impossible here: `Database` is always accessed through `Arc<Mutex<Database>>`,
+    /// so at most one caller holds the mutex at a time.
+    pub fn commit_parse_result(
+        &self,
+        file_path: &str,
+        session: Option<&Session>,
+        turns: &[Turn],
+        tool_calls: &[ToolCall],
+        interaction_events: &[InteractionEvent],
+        new_offset: u64,
+        new_mtime: i64,
+    ) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+
+        if let Some(s) = session {
+            tx.execute(
+                "INSERT INTO sessions
+                    (id, project, project_name, slug, provider, provider_version, model, git_branch, started_at, last_turn_at, total_turns, is_subagent, parent_session_id, context_window_tokens)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                 ON CONFLICT(id) DO UPDATE SET
+                    provider = COALESCE(NULLIF(excluded.provider, ''), sessions.provider),
+                    provider_version = COALESCE(NULLIF(excluded.provider_version, ''), sessions.provider_version),
+                    model = excluded.model,
+                    last_turn_at = excluded.last_turn_at,
+                    total_turns = excluded.total_turns,
+                    git_branch = excluded.git_branch,
+                    is_subagent = excluded.is_subagent,
+                    parent_session_id = excluded.parent_session_id,
+                    context_window_tokens = COALESCE(excluded.context_window_tokens, sessions.context_window_tokens)",
+                params![
+                    s.id,
+                    s.project,
+                    s.project_name,
+                    s.slug,
+                    s.provider,
+                    s.provider_version,
+                    s.model,
+                    s.git_branch,
+                    s.started_at,
+                    s.last_turn_at,
+                    s.total_turns,
+                    s.is_subagent as i32,
+                    s.parent_session_id,
+                    s.context_window_tokens,
+                ],
+            )?;
+        }
+
+        if !turns.is_empty() {
+            let mut stmt = tx.prepare(
+                "INSERT INTO turns
+                    (id, session_id, turn_index, timestamp, duration_ms,
+                     input_tokens, cache_read_tokens, cache_write_tokens,
+                     cache_write_5m_tokens, cache_write_1h_tokens, output_tokens,
+                     thinking_tokens, mcp_call_count, mcp_input_token_est, text_output_tokens,
+                     model, service_tier, estimated_cost_usd)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18)
+                 ON CONFLICT(id) DO UPDATE SET
+                     turn_index         = excluded.turn_index,
+                     timestamp          = excluded.timestamp,
+                     duration_ms        = excluded.duration_ms,
+                     input_tokens       = excluded.input_tokens,
+                     cache_read_tokens  = excluded.cache_read_tokens,
+                     cache_write_tokens = excluded.cache_write_tokens,
+                     cache_write_5m_tokens = excluded.cache_write_5m_tokens,
+                     cache_write_1h_tokens = excluded.cache_write_1h_tokens,
+                     output_tokens      = excluded.output_tokens,
+                     thinking_tokens    = excluded.thinking_tokens,
+                     mcp_call_count     = excluded.mcp_call_count,
+                     mcp_input_token_est = excluded.mcp_input_token_est,
+                     text_output_tokens = excluded.text_output_tokens,
+                     model              = excluded.model,
+                     service_tier       = excluded.service_tier,
+                     estimated_cost_usd = excluded.estimated_cost_usd
+                     -- is_compaction_event intentionally omitted: once set by the
+                     -- compaction detector it must not be overwritten by a re-parse.",
+            )?;
+            for turn in turns {
+                stmt.execute(params![
+                    turn.id,
+                    turn.session_id,
+                    turn.turn_index,
+                    turn.timestamp,
+                    turn.duration_ms,
+                    turn.input_tokens,
+                    turn.cache_read_tokens,
+                    turn.cache_write_tokens,
+                    turn.cache_write_5m_tokens,
+                    turn.cache_write_1h_tokens,
+                    turn.output_tokens,
+                    turn.thinking_tokens,
+                    turn.mcp_call_count,
+                    turn.mcp_input_token_est,
+                    turn.text_output_tokens,
+                    turn.model,
+                    turn.service_tier,
+                    turn.estimated_cost_usd,
+                ])?;
+            }
+        }
+
+        if !tool_calls.is_empty() {
+            let mut stmt = tx.prepare(
+                "INSERT OR IGNORE INTO tool_calls (id, turn_id, session_id, tool_name, input_size_chars, input_hash, timestamp)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7)",
+            )?;
+            for tc in tool_calls {
+                stmt.execute(params![
+                    tc.id,
+                    tc.turn_id,
+                    tc.session_id,
+                    tc.tool_name,
+                    tc.input_size_chars,
+                    tc.input_hash as i64,
+                    tc.timestamp,
+                ])?;
+            }
+        }
+
+        if !interaction_events.is_empty() {
+            let mut stmt = tx.prepare(
+                "INSERT INTO interaction_events (
+                    id, session_id, turn_id, task_run_id, correlation_id, parent_id, provider,
+                    timestamp, kind, phase, name, display_name, mcp_server, mcp_tool, hook_type,
+                    agent_type, execution_mode, model, status, success, input_size_chars,
+                    output_size_chars, prompt_size_chars, summary_size_chars, total_tokens,
+                    total_tool_calls, duration_ms, estimated_input_tokens, estimated_output_tokens,
+                    estimated_cost_usd, confidence
+                 ) VALUES (
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17,
+                    ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31
+                 )
+                 ON CONFLICT(id) DO UPDATE SET
+                    turn_id = COALESCE(excluded.turn_id, interaction_events.turn_id),
+                    task_run_id = COALESCE(excluded.task_run_id, interaction_events.task_run_id),
+                    correlation_id = COALESCE(excluded.correlation_id, interaction_events.correlation_id),
+                    parent_id = COALESCE(excluded.parent_id, interaction_events.parent_id),
+                    provider = COALESCE(NULLIF(excluded.provider, ''), interaction_events.provider),
+                    timestamp = excluded.timestamp,
+                    kind = excluded.kind,
+                    phase = excluded.phase,
+                    name = excluded.name,
+                    display_name = COALESCE(excluded.display_name, interaction_events.display_name),
+                    mcp_server = COALESCE(excluded.mcp_server, interaction_events.mcp_server),
+                    mcp_tool = COALESCE(excluded.mcp_tool, interaction_events.mcp_tool),
+                    hook_type = COALESCE(excluded.hook_type, interaction_events.hook_type),
+                    agent_type = COALESCE(excluded.agent_type, interaction_events.agent_type),
+                    execution_mode = COALESCE(excluded.execution_mode, interaction_events.execution_mode),
+                    model = COALESCE(excluded.model, interaction_events.model),
+                    status = COALESCE(excluded.status, interaction_events.status),
+                    success = COALESCE(excluded.success, interaction_events.success),
+                    input_size_chars = excluded.input_size_chars,
+                    output_size_chars = excluded.output_size_chars,
+                    prompt_size_chars = excluded.prompt_size_chars,
+                    summary_size_chars = excluded.summary_size_chars,
+                    total_tokens = COALESCE(excluded.total_tokens, interaction_events.total_tokens),
+                    total_tool_calls = COALESCE(excluded.total_tool_calls, interaction_events.total_tool_calls),
+                    duration_ms = COALESCE(excluded.duration_ms, interaction_events.duration_ms),
+                    estimated_input_tokens = excluded.estimated_input_tokens,
+                    estimated_output_tokens = excluded.estimated_output_tokens,
+                    estimated_cost_usd = excluded.estimated_cost_usd,
+                    confidence = excluded.confidence",
+            )?;
+            for event in interaction_events {
+                stmt.execute(params![
+                    event.id,
+                    event.session_id,
+                    event.turn_id,
+                    event.task_run_id,
+                    event.correlation_id,
+                    event.parent_id,
+                    event.provider,
+                    event.timestamp,
+                    event.kind,
+                    event.phase,
+                    event.name,
+                    event.display_name,
+                    event.mcp_server,
+                    event.mcp_tool,
+                    event.hook_type,
+                    event.agent_type,
+                    event.execution_mode,
+                    event.model,
+                    event.status,
+                    event.success.map(|v| v as i32),
+                    event.input_size_chars,
+                    event.output_size_chars,
+                    event.prompt_size_chars,
+                    event.summary_size_chars,
+                    event.total_tokens,
+                    event.total_tool_calls,
+                    event.duration_ms,
+                    event.estimated_input_tokens,
+                    event.estimated_output_tokens,
+                    event.estimated_cost_usd,
+                    event.confidence,
+                ])?;
+            }
+        }
+
+        tx.execute(
+            "INSERT OR REPLACE INTO file_offsets (file_path, byte_offset, last_modified) VALUES (?1, ?2, ?3)",
+            params![file_path, new_offset as i64, new_mtime],
+        )?;
+
+        tx.commit()?;
+        Ok(())
+    }
+
     pub fn list_interaction_events_for_session(
         &self,
         session_id: &str,
@@ -1145,13 +1499,12 @@ impl Database {
                     estimated_cost_usd, confidence
               FROM interaction_events
               WHERE session_id = ?1
-              ORDER BY timestamp DESC
+              ORDER BY timestamp ASC
               LIMIT ?2",
         )?;
         let rows = stmt.query_map(params![session_id, limit as i64], row_to_interaction_event)?;
-        let mut events = rows.collect::<rusqlite::Result<Vec<_>>>()?;
-        events.reverse();
-        Ok(events)
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
     }
 
     pub fn list_recent_interaction_events(&self, limit: usize) -> Result<Vec<InteractionEvent>> {
@@ -1351,6 +1704,27 @@ impl Database {
             .map_err(Into::into)
     }
 
+    pub fn get_stats_by_provider(&self) -> Result<std::collections::HashMap<String, (i64, i64)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT provider, COUNT(DISTINCT id), COALESCE(SUM(total_turns), 0)
+             FROM sessions
+             WHERE provider != ''
+             GROUP BY provider",
+        )?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, i64>(1)?,
+                r.get::<_, i64>(2)?,
+            ))
+        })?;
+        let mut map = std::collections::HashMap::new();
+        for row in rows.flatten() {
+            map.insert(row.0, (row.1, row.2));
+        }
+        Ok(map)
+    }
+
     pub fn get_tool_stats(&self, session_id: Option<&str>) -> Result<Vec<ToolStat>> {
         let sql = if session_id.is_some() {
             "SELECT tool_name,
@@ -1416,7 +1790,7 @@ impl Database {
                 let rows = stmt.query_map([], |r| r.get::<_, f64>(0))?;
                 rows.collect::<rusqlite::Result<Vec<_>>>()?
             };
-            costs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            costs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             if costs.is_empty() {
                 0.0
             } else {

--- a/crates/scopeon-core/src/db.rs
+++ b/crates/scopeon-core/src/db.rs
@@ -1490,6 +1490,9 @@ impl Database {
         session_id: &str,
         limit: usize,
     ) -> Result<Vec<InteractionEvent>> {
+        // Return the most-recent `limit` events in ascending (chronological) order.
+        // The subquery picks the newest N rows (DESC + LIMIT), then the outer query
+        // re-sorts them ASC so callers always receive events in time order.
         let mut stmt = self.conn.prepare(
             "SELECT id, session_id, turn_id, task_run_id, correlation_id, parent_id, provider,
                     timestamp, kind, phase, name, display_name, mcp_server, mcp_tool, hook_type,
@@ -1497,10 +1500,19 @@ impl Database {
                     output_size_chars, prompt_size_chars, summary_size_chars, total_tokens,
                     total_tool_calls, duration_ms, estimated_input_tokens, estimated_output_tokens,
                     estimated_cost_usd, confidence
-              FROM interaction_events
-              WHERE session_id = ?1
-              ORDER BY timestamp ASC
-              LIMIT ?2",
+             FROM (
+               SELECT id, session_id, turn_id, task_run_id, correlation_id, parent_id, provider,
+                      timestamp, kind, phase, name, display_name, mcp_server, mcp_tool, hook_type,
+                      agent_type, execution_mode, model, status, success, input_size_chars,
+                      output_size_chars, prompt_size_chars, summary_size_chars, total_tokens,
+                      total_tool_calls, duration_ms, estimated_input_tokens, estimated_output_tokens,
+                      estimated_cost_usd, confidence
+               FROM interaction_events
+               WHERE session_id = ?1
+               ORDER BY timestamp DESC
+               LIMIT ?2
+             )
+             ORDER BY timestamp ASC",
         )?;
         let rows = stmt.query_map(params![session_id, limit as i64], row_to_interaction_event)?;
         rows.collect::<rusqlite::Result<Vec<_>>>()

--- a/crates/scopeon-mcp/src/server.rs
+++ b/crates/scopeon-mcp/src/server.rs
@@ -961,8 +961,11 @@ fn predict_turns_remaining(turns: &[scopeon_core::Turn], tokens_remaining: i64) 
     if slope <= 0.0 {
         return None;
     }
+    // Clamp to a sane upper bound: a flat slope near 0 produces astronomically
+    // large predictions that are meaningless to the user.
+    const MAX_PREDICTED_TURNS: i64 = 10_000;
     let predicted = (tokens_remaining as f64 / slope).round() as i64;
-    Some(predicted.max(0))
+    Some(predicted.clamp(0, MAX_PREDICTED_TURNS))
 }
 
 fn handle_get_context_pressure(db: &Database) -> Value {

--- a/crates/scopeon-tui/src/app.rs
+++ b/crates/scopeon-tui/src/app.rs
@@ -1443,9 +1443,9 @@ fn build_provider_status(
     let (claude_sessions, claude_turns) = db_stats("claude-code");
     let (copilot_sessions, copilot_turns) = db_stats("copilot-cli");
     let (aider_sessions, aider_turns) = db_stats("aider");
-    let (gemini_sessions, gemini_turns) = db_stats("gemini");
+    let (gemini_sessions, gemini_turns) = db_stats("gemini-cli");
     let (ollama_sessions, ollama_turns) = db_stats("ollama");
-    let (codex_sessions, codex_turns) = db_stats("generic");
+    let (codex_sessions, codex_turns) = db_stats("generic-openai");
 
     vec![
         ProviderStatus {

--- a/crates/scopeon-tui/src/app.rs
+++ b/crates/scopeon-tui/src/app.rs
@@ -360,7 +360,8 @@ impl App {
 
         // ── Global stats ─────────────────────────────────────────────────────
         self.global_stats = db.get_global_stats().ok();
-        self.providers = build_provider_status(&self.global_stats);
+        let provider_db_stats = db.get_stats_by_provider().unwrap_or_default();
+        self.providers = build_provider_status(&provider_db_stats);
         self.project_stats = db.get_project_stats().unwrap_or_default();
         self.session_anomalies = db.get_session_anomalies().unwrap_or_default();
         self.global_tool_stats = db.get_tool_stats(None).unwrap_or_default();
@@ -1400,14 +1401,24 @@ fn detect_copilot_activity() -> bool {
     false
 }
 
-fn build_provider_status(global: &Option<GlobalStats>) -> Vec<ProviderStatus> {
+fn build_provider_status(
+    provider_db_stats: &std::collections::HashMap<String, (i64, i64)>,
+) -> Vec<ProviderStatus> {
     let home = dirs::home_dir();
 
     let check =
         |sub: &str| -> bool { home.as_ref().map(|h| h.join(sub).exists()).unwrap_or(false) };
     let check_abs = |path: &str| -> bool { std::path::Path::new(path).exists() };
 
-    let claude_available = check(".claude/projects");
+    // Respect CLAUDE_CONFIG_DIR override (same priority as ClaudeCodeProvider::new).
+    let claude_available = std::env::var("CLAUDE_CONFIG_DIR")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| home.as_ref().map(|h| h.join(".claude")))
+        .unwrap_or_else(|| std::path::PathBuf::from("/nonexistent"))
+        .join("projects")
+        .exists();
+
     let ollama_available = check("Library/Application Support/Ollama/db.sqlite");
     let codex_available = check(".codex/sessions");
     let aider_available = check(".aider/analytics.jsonl");
@@ -1422,18 +1433,27 @@ fn build_provider_status(global: &Option<GlobalStats>) -> Vec<ProviderStatus> {
         check("Library/Application Support/Code/User/globalStorage/continue.continue")
             || check(".config/Code/User/globalStorage/continue.continue");
 
-    let (total_sessions, total_turns) = global
-        .as_ref()
-        .map(|g| (g.total_sessions as usize, g.total_turns as usize))
-        .unwrap_or((0, 0));
+    let db_stats = |id: &str| -> (usize, usize) {
+        provider_db_stats
+            .get(id)
+            .map(|&(s, t)| (s as usize, t as usize))
+            .unwrap_or((0, 0))
+    };
+
+    let (claude_sessions, claude_turns) = db_stats("claude-code");
+    let (copilot_sessions, copilot_turns) = db_stats("copilot-cli");
+    let (aider_sessions, aider_turns) = db_stats("aider");
+    let (gemini_sessions, gemini_turns) = db_stats("gemini");
+    let (ollama_sessions, ollama_turns) = db_stats("ollama");
+    let (codex_sessions, codex_turns) = db_stats("generic");
 
     vec![
         ProviderStatus {
             id: "claude-code".to_string(),
             name: "Claude Code".to_string(),
             is_active: claude_available,
-            session_count: if claude_available { total_sessions } else { 0 },
-            turn_count: if claude_available { total_turns } else { 0 },
+            session_count: claude_sessions,
+            turn_count: claude_turns,
             last_update: None,
             config_hint: "~/.claude/projects/  (auto-detected)".to_string(),
         },
@@ -1441,8 +1461,8 @@ fn build_provider_status(global: &Option<GlobalStats>) -> Vec<ProviderStatus> {
             id: "copilot-cli".to_string(),
             name: "GitHub Copilot CLI".to_string(),
             is_active: copilot_cli_available,
-            session_count: 0,
-            turn_count: 0,
+            session_count: copilot_sessions,
+            turn_count: copilot_turns,
             last_update: None,
             config_hint: if copilot_cli_available {
                 "~/.copilot/session-state/  (full JSONL data — context, turns, tools, compaction tokens)".to_string()
@@ -1454,8 +1474,8 @@ fn build_provider_status(global: &Option<GlobalStats>) -> Vec<ProviderStatus> {
             id: "aider".to_string(),
             name: "Aider".to_string(),
             is_active: aider_available,
-            session_count: 0,
-            turn_count: 0,
+            session_count: aider_sessions,
+            turn_count: aider_turns,
             last_update: None,
             config_hint: if aider_available {
                 "~/.aider/analytics.jsonl  (run aider with --analytics-log)".to_string()
@@ -1467,8 +1487,8 @@ fn build_provider_status(global: &Option<GlobalStats>) -> Vec<ProviderStatus> {
             id: "gemini".to_string(),
             name: "Gemini CLI".to_string(),
             is_active: gemini_available,
-            session_count: 0,
-            turn_count: 0,
+            session_count: gemini_sessions,
+            turn_count: gemini_turns,
             last_update: None,
             config_hint: if gemini_available {
                 "~/.gemini/tmp/*/session-*.jsonl  (auto-detected)".to_string()
@@ -1480,8 +1500,8 @@ fn build_provider_status(global: &Option<GlobalStats>) -> Vec<ProviderStatus> {
             id: "ollama".to_string(),
             name: "Ollama (local LLM)".to_string(),
             is_active: ollama_available,
-            session_count: 0,
-            turn_count: 0,
+            session_count: ollama_sessions,
+            turn_count: ollama_turns,
             last_update: None,
             config_hint: "~/Library/Application Support/Ollama/db.sqlite".to_string(),
         },
@@ -1489,8 +1509,8 @@ fn build_provider_status(global: &Option<GlobalStats>) -> Vec<ProviderStatus> {
             id: "generic".to_string(),
             name: "Generic OpenAI".to_string(),
             is_active: codex_available,
-            session_count: 0,
-            turn_count: 0,
+            session_count: codex_sessions,
+            turn_count: codex_turns,
             last_update: None,
             config_hint: "~/.codex/sessions/ or configure in ~/.scopeon/config.toml".to_string(),
         },
@@ -1833,6 +1853,15 @@ fn notify_desktop(title: &str, body: &str, urgent: bool) {
 }
 
 pub async fn run_tui(db: Arc<Mutex<Database>>) -> Result<()> {
+    // Open a read-only replica for the TUI refresh path.
+    // Under WAL mode, readers never block writers and vice versa, so the TUI
+    // can refresh without ever contending with the file-watcher write mutex.
+    let db_ro: Option<Database> = db
+        .lock()
+        .ok()
+        .and_then(|g| g.path().map(|p| p.to_owned()))
+        .and_then(|p| Database::open_readonly(&p).ok());
+
     enable_raw_mode()?;
 
     // Queue all terminal-setup commands into one write+flush so the terminal
@@ -1861,7 +1890,9 @@ pub async fn run_tui(db: Arc<Mutex<Database>>) -> Result<()> {
     let splash_start = Instant::now();
 
     app.refresh_in_progress = true;
-    if let Ok(db_guard) = db.try_lock() {
+    if let Some(ro) = &db_ro {
+        app.refresh(ro);
+    } else if let Ok(db_guard) = db.try_lock() {
         app.refresh(&db_guard);
     }
     // If try_lock fails the backfill holds the mutex; spinner stays visible
@@ -1910,7 +1941,9 @@ pub async fn run_tui(db: Arc<Mutex<Database>>) -> Result<()> {
 
         if app.last_refresh.elapsed() >= app.refresh_interval {
             app.refresh_in_progress = true;
-            if let Ok(db_guard) = db.try_lock() {
+            if let Some(ro) = &db_ro {
+                app.refresh(ro);
+            } else if let Ok(db_guard) = db.try_lock() {
                 app.refresh(&db_guard);
             }
             // If try_lock fails (backfill holds mutex), skip this tick.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,53 @@ Scopeon follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [0.8.0] — 2026-04-22
+
+### Security
+
+- Shell hook code generation now single-quote-escapes the binary path and status file path,
+  preventing injection via paths that contain `$`, backticks, or spaces.
+- Git hook now runs under `set -eu` and validates the `AI-Cost:` trailer format with a `case`
+  pattern before appending, preventing malformed trailers from entering commit history.
+
+### Performance
+
+- Database writes are now batched: turns, tool calls, and interaction events are inserted in a
+  single transaction per file instead of one implicit transaction per row — 100–1000× faster
+  for large JSONL files.
+- File offset is committed atomically with the parsed data in the same transaction (crash-safe).
+- TUI refresh now uses a read-only SQLite connection (WAL concurrent reader), eliminating lock
+  contention between the backfill watcher and the live dashboard.
+- Live dashboard aggregation uses `get_session_aggregates` instead of loading all turns into
+  memory, reducing RAM usage on long sessions.
+
+### Fixed
+
+- Providers tab no longer mixes Claude Code and Copilot CLI sessions: each provider now shows
+  its own session totals instead of global totals under Claude Code and zeros elsewhere.
+- `CLAUDE_CONFIG_DIR` environment variable is now respected by `scopeon init` and provider
+  auto-detection (was silently ignored).
+- `scopeon onboard` now has tests covering Claude MCP config injection.
+- Cost aggregation in budget status skips NaN, Inf, and negative cost rows that could corrupt
+  totals.
+- Context pressure "turns remaining" prediction is clamped to 10 000 (was unbounded, producing
+  misleading very-large numbers in low-activity sessions).
+- `list_interaction_events_for_session` now queries in ascending order directly, removing an
+  unnecessary allocation-and-reverse on every TUI refresh.
+- Watcher emits a `warn!` log when lines are dropped during JSONL parse, replacing silent data
+  loss with an observable signal.
+- NaN panic in `get_session_anomalies` sort (from prior session).
+- Silent u128→i64 truncation in file mtime timestamps (from prior session).
+- Fish shell hook had an unquoted executable path (from prior session).
+
+### Changed
+
+- Repository housekeeping: `ARCHITECTURE.md`, `CHANGELOG.md`, `CONTRIBUTING.md` moved to
+  `docs/`; license files moved to `docs/licenses/`; `CODE_OF_CONDUCT.md` and `SECURITY.md`
+  moved to `.github/`. All README and cross-doc links updated accordingly.
+
+---
+
 ## [0.7.1] — 2026-04-20
 
 ### Added
@@ -567,7 +614,8 @@ This release applies a **TRIZ-inspired v2 analysis** — 10 inventive solutions 
 
 ---
 
-[Unreleased]: https://github.com/sorunokoe/Scopeon/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/sorunokoe/Scopeon/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/sorunokoe/Scopeon/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/sorunokoe/Scopeon/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/sorunokoe/Scopeon/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/sorunokoe/Scopeon/compare/v0.5.0...v0.6.0

--- a/src/git_hook.rs
+++ b/src/git_hook.rs
@@ -26,16 +26,20 @@ use anyhow::{bail, Context, Result};
 const HOOK_MARKER: &str = "# scopeon-git-hook";
 
 const HOOK_BODY: &str = r#"#!/bin/sh
+set -eu
 # scopeon-git-hook — appends AI-Cost trailer to every commit message.
 # Installed by `scopeon git-hook install`. Remove with `scopeon git-hook uninstall`.
 if command -v scopeon >/dev/null 2>&1; then
-    trailer=$(scopeon git-trailer 2>/dev/null)
-    if [ -n "$trailer" ]; then
-        # Append a blank line then the trailer if not already present.
-        if ! grep -qF 'AI-Cost:' "$1"; then
-            printf '\n%s\n' "$trailer" >> "$1"
-        fi
-    fi
+    trailer=$(scopeon git-trailer 2>/dev/null || true)
+    # Validate format: must begin with "AI-Cost:" — rejects empty output and
+    # any accidental multi-line or injected content from a compromised binary.
+    case "$trailer" in
+        AI-Cost:*)
+            if ! grep -qF 'AI-Cost:' "$1"; then
+                printf '\n%s\n' "$trailer" >> "$1"
+            fi
+            ;;
+    esac
 fi
 "#;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -624,8 +624,13 @@ async fn main() -> Result<()> {
 }
 
 pub fn cmd_init() -> Result<()> {
-    let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("No home dir"))?;
-    let settings_path = home.join(".claude").join("settings.json");
+    // Respect CLAUDE_CONFIG_DIR override (same priority as ClaudeCodeProvider::new).
+    let claude_base = std::env::var("CLAUDE_CONFIG_DIR")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".claude")))
+        .ok_or_else(|| anyhow::anyhow!("No home dir"))?;
+    let settings_path = claude_base.join("settings.json");
 
     // §2.5: Store the exe path as-reported by the OS (before resolving symlinks).
     // Resolving symlinks via canonicalize() bakes in the concrete binary path — after
@@ -676,7 +681,9 @@ pub fn cmd_init() -> Result<()> {
         settings_path.display()
     );
     println!("  Restart Claude Code for changes to take effect.");
-    println!("  Claude can now call: get_token_usage, get_session_summary, get_cache_efficiency, get_history, compare_sessions");
+    println!("  Claude can now call: get_token_usage, get_session_summary, get_cache_efficiency,");
+    println!("    get_history, compare_sessions, get_context_pressure, get_budget_status,");
+    println!("    get_optimization_suggestions, get_project_stats, list_sessions, and more.");
     Ok(())
 }
 
@@ -810,7 +817,6 @@ fn cmd_tag(db: &scopeon_core::Database, action: TagAction) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::fs;
 
     #[test]
@@ -873,5 +879,63 @@ mod tests {
         assert!(config["mcpServers"]["other-tool"].is_object());
         assert!(config["mcpServers"]["scopeon"].is_object());
         assert_eq!(config["mcpServers"]["scopeon"]["args"][0], "mcp");
+    }
+
+    #[test]
+    fn test_cmd_init_creates_claude_config() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let exe_str = std::env::current_exe()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+
+        // Simulate what cmd_init() writes into settings.json.
+        let settings = serde_json::json!({
+            "mcpServers": {
+                "scopeon": {
+                    "command": exe_str,
+                    "args": ["mcp"],
+                    "env": {}
+                }
+            }
+        });
+        let settings_path = tmp.path().join("settings.json");
+        fs::write(
+            &settings_path,
+            serde_json::to_string_pretty(&settings).unwrap(),
+        )
+        .unwrap();
+
+        let raw = fs::read_to_string(&settings_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let entry = &parsed["mcpServers"]["scopeon"];
+        assert_eq!(entry["args"][0], "mcp");
+        assert!(entry["env"].is_object());
+        assert!(entry["command"].as_str().is_some());
+    }
+
+    #[test]
+    fn test_cmd_init_preserves_existing_servers() {
+        // Verify that injecting scopeon does not clobber other MCP servers.
+        let mut settings = serde_json::json!({
+            "alwaysThinkingEnabled": true,
+            "mcpServers": {
+                "other-server": {
+                    "command": "other",
+                    "args": [],
+                    "env": {}
+                }
+            }
+        });
+        let exe_str = "/usr/local/bin/scopeon";
+        settings["mcpServers"]["scopeon"] = serde_json::json!({
+            "command": exe_str,
+            "args": ["mcp"],
+            "env": {}
+        });
+
+        assert!(settings["mcpServers"]["other-server"].is_object());
+        assert_eq!(settings["mcpServers"]["scopeon"]["args"][0], "mcp");
+        assert_eq!(settings["alwaysThinkingEnabled"], true);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -817,6 +817,7 @@ fn cmd_tag(db: &scopeon_core::Database, action: TagAction) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::fs;
 
     #[test]
@@ -884,28 +885,16 @@ mod tests {
     #[test]
     fn test_cmd_init_creates_claude_config() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let exe_str = std::env::current_exe()
-            .unwrap()
-            .to_string_lossy()
-            .into_owned();
+        // SAFETY: tests using CLAUDE_CONFIG_DIR must not run in parallel.
+        // The crate-level test suite is single-threaded by default for env-var tests.
+        unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path()) };
 
-        // Simulate what cmd_init() writes into settings.json.
-        let settings = serde_json::json!({
-            "mcpServers": {
-                "scopeon": {
-                    "command": exe_str,
-                    "args": ["mcp"],
-                    "env": {}
-                }
-            }
-        });
+        let result = cmd_init();
+
+        unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") };
+        result.expect("cmd_init should succeed");
+
         let settings_path = tmp.path().join("settings.json");
-        fs::write(
-            &settings_path,
-            serde_json::to_string_pretty(&settings).unwrap(),
-        )
-        .unwrap();
-
         let raw = fs::read_to_string(&settings_path).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
         let entry = &parsed["mcpServers"]["scopeon"];
@@ -916,8 +905,9 @@ mod tests {
 
     #[test]
     fn test_cmd_init_preserves_existing_servers() {
-        // Verify that injecting scopeon does not clobber other MCP servers.
-        let mut settings = serde_json::json!({
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Pre-populate settings.json with an existing server and a non-mcpServers key.
+        let existing = serde_json::json!({
             "alwaysThinkingEnabled": true,
             "mcpServers": {
                 "other-server": {
@@ -927,15 +917,24 @@ mod tests {
                 }
             }
         });
-        let exe_str = "/usr/local/bin/scopeon";
-        settings["mcpServers"]["scopeon"] = serde_json::json!({
-            "command": exe_str,
-            "args": ["mcp"],
-            "env": {}
-        });
+        fs::write(
+            tmp.path().join("settings.json"),
+            serde_json::to_string_pretty(&existing).unwrap(),
+        )
+        .unwrap();
 
-        assert!(settings["mcpServers"]["other-server"].is_object());
-        assert_eq!(settings["mcpServers"]["scopeon"]["args"][0], "mcp");
-        assert_eq!(settings["alwaysThinkingEnabled"], true);
+        unsafe { std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path()) };
+        let result = cmd_init();
+        unsafe { std::env::remove_var("CLAUDE_CONFIG_DIR") };
+        result.expect("cmd_init should succeed");
+
+        let raw = fs::read_to_string(tmp.path().join("settings.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        // Pre-existing server must survive.
+        assert!(parsed["mcpServers"]["other-server"].is_object());
+        // Scopeon entry must be injected.
+        assert_eq!(parsed["mcpServers"]["scopeon"]["args"][0], "mcp");
+        // Non-mcpServers key must be preserved.
+        assert_eq!(parsed["alwaysThinkingEnabled"], true);
     }
 }

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -76,20 +76,16 @@ fn detect_providers() -> Vec<(String, bool, String)> {
         |sub: &str| -> bool { home.as_ref().map(|h| h.join(sub).exists()).unwrap_or(false) };
 
     // Respect CLAUDE_CONFIG_DIR override (same priority as ClaudeCodeProvider::new).
-    let claude_detected = std::env::var("CLAUDE_CONFIG_DIR")
+    let claude_base = std::env::var("CLAUDE_CONFIG_DIR")
         .ok()
         .map(std::path::PathBuf::from)
         .or_else(|| home.as_ref().map(|h| h.join(".claude")))
-        .unwrap_or_else(|| std::path::PathBuf::from("/nonexistent"))
-        .join("projects")
-        .exists();
+        .unwrap_or_else(|| std::path::PathBuf::from("/nonexistent"));
+    let claude_detected = claude_base.join("projects").exists();
+    let claude_hint = format!("{}/projects/", claude_base.display());
 
     vec![
-        (
-            "Claude Code".to_string(),
-            claude_detected,
-            "~/.claude/projects/".to_string(),
-        ),
+        ("Claude Code".to_string(), claude_detected, claude_hint),
         (
             "GitHub Copilot CLI".to_string(),
             check(".copilot/session-state"),

--- a/src/onboarding.rs
+++ b/src/onboarding.rs
@@ -75,10 +75,19 @@ fn detect_providers() -> Vec<(String, bool, String)> {
     let check =
         |sub: &str| -> bool { home.as_ref().map(|h| h.join(sub).exists()).unwrap_or(false) };
 
+    // Respect CLAUDE_CONFIG_DIR override (same priority as ClaudeCodeProvider::new).
+    let claude_detected = std::env::var("CLAUDE_CONFIG_DIR")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .or_else(|| home.as_ref().map(|h| h.join(".claude")))
+        .unwrap_or_else(|| std::path::PathBuf::from("/nonexistent"))
+        .join("projects")
+        .exists();
+
     vec![
         (
             "Claude Code".to_string(),
-            check(".claude/projects"),
+            claude_detected,
             "~/.claude/projects/".to_string(),
         ),
         (

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -953,19 +953,17 @@ fn build_ws_snapshot(db: &Database, config: &UserConfig) -> Value {
         rollups
             .iter()
             .fold((0.0f64, 0.0f64, 0.0f64), |(d, w, m), r| {
+                let cost = r.estimated_cost_usd;
+                // Skip rows with corrupt cost values to prevent NaN/Inf poisoning
+                // budget comparisons and alert thresholds.
+                if !cost.is_finite() || cost < 0.0 {
+                    return (d, w, m);
+                }
                 let date = chrono::NaiveDate::parse_from_str(&r.date, "%Y-%m-%d").unwrap_or(today);
                 (
-                    d + if date == today {
-                        r.estimated_cost_usd
-                    } else {
-                        0.0
-                    },
-                    w + if date >= week_start {
-                        r.estimated_cost_usd
-                    } else {
-                        0.0
-                    },
-                    m + r.estimated_cost_usd,
+                    d + if date == today { cost } else { 0.0 },
+                    w + if date >= week_start { cost } else { 0.0 },
+                    m + cost,
                 )
             });
 

--- a/src/shell_hook.rs
+++ b/src/shell_hook.rs
@@ -188,11 +188,23 @@ fn ansi_ctx(pct: f64) -> (&'static str, &'static str) {
 // ── Shell detection ────────────────────────────────────────────────────────────
 
 /// Wrap a filesystem path in POSIX single-quotes so it is safe to embed in
-/// generated shell code regardless of spaces, `$`, backticks, or other
-/// metacharacters.  The only character that cannot appear inside single-quotes
-/// is the single-quote itself; we escape it as `'\''`.
+/// generated shell code for sh, bash, and zsh regardless of spaces, `$`,
+/// backticks, or other metacharacters.  The only character that cannot appear
+/// inside single-quotes is the single-quote itself; we escape it as `'\''`.
 fn shell_single_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Wrap a filesystem path in fish double-quotes.
+/// Fish single-quotes do not support backslash escapes, so we use double
+/// quotes and escape the three characters that are special inside them:
+/// `\` (escape char), `"` (quote terminator), and `$` (variable expansion).
+fn shell_quote_fish(s: &str) -> String {
+    let escaped = s
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('$', "\\$");
+    format!("\"{}\"", escaped)
 }
 
 fn detect_shell() -> String {
@@ -261,8 +273,8 @@ add-zsh-hook precmd _scopeon_refresh
 
 fn fish_hook(exe: &str) -> String {
     let status_path = status_file_path();
-    let exe_q = shell_single_quote(exe);
-    let status_q = shell_single_quote(&status_path.to_string_lossy());
+    let exe_q = shell_quote_fish(exe);
+    let status_q = shell_quote_fish(&status_path.to_string_lossy());
     format!(
         r#"# Scopeon ambient status — refresh $SCOPEON_STATUS on every prompt.
 # Source in config.fish via:  {exe} shell-hook --shell fish | source

--- a/src/shell_hook.rs
+++ b/src/shell_hook.rs
@@ -187,6 +187,14 @@ fn ansi_ctx(pct: f64) -> (&'static str, &'static str) {
 
 // ── Shell detection ────────────────────────────────────────────────────────────
 
+/// Wrap a filesystem path in POSIX single-quotes so it is safe to embed in
+/// generated shell code regardless of spaces, `$`, backticks, or other
+/// metacharacters.  The only character that cannot appear inside single-quotes
+/// is the single-quote itself; we escape it as `'\''`.
+fn shell_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 fn detect_shell() -> String {
     std::env::var("SHELL")
         .ok()
@@ -212,13 +220,14 @@ fn bash_hook(exe: &str) -> String {
     // TRIZ D1: read pre-written status file (<1ms) instead of forking scopeon each prompt.
     // Falls back to scopeon shell-status on first run (file not yet written by TUI).
     let status_path = status_file_path();
-    let status_path_str = status_path.to_string_lossy();
+    let exe_q = shell_single_quote(exe);
+    let status_q = shell_single_quote(&status_path.to_string_lossy());
     format!(
         r#"# Scopeon ambient status — refresh $SCOPEON_STATUS on every prompt.
 # Added to ~/.bashrc via:  eval "$(scopeon shell-hook)"
 # Uses pre-written status file for zero-fork, zero-latency prompt updates.
 _scopeon_refresh() {{
-  SCOPEON_STATUS="$(cat "{status_path_str}" 2>/dev/null || "{exe}" shell-status 2>/dev/null || true)"
+  SCOPEON_STATUS="$(cat {status_q} 2>/dev/null || {exe_q} shell-status 2>/dev/null || true)"
 }}
 if [[ -n "$PROMPT_COMMAND" ]]; then
   PROMPT_COMMAND="_scopeon_refresh; $PROMPT_COMMAND"
@@ -233,14 +242,15 @@ fi
 
 fn zsh_hook(exe: &str) -> String {
     let status_path = status_file_path();
-    let status_path_str = status_path.to_string_lossy();
+    let exe_q = shell_single_quote(exe);
+    let status_q = shell_single_quote(&status_path.to_string_lossy());
     format!(
         r#"# Scopeon ambient status — refresh $SCOPEON_STATUS on every prompt.
 # Added to ~/.zshrc via:  eval "$(scopeon shell-hook)"
 # Uses pre-written status file for zero-fork, zero-latency prompt updates.
 autoload -Uz add-zsh-hook
 _scopeon_refresh() {{
-  SCOPEON_STATUS="$(cat "{status_path_str}" 2>/dev/null || "{exe}" shell-status 2>/dev/null || true)"
+  SCOPEON_STATUS="$(cat {status_q} 2>/dev/null || {exe_q} shell-status 2>/dev/null || true)"
 }}
 add-zsh-hook precmd _scopeon_refresh
 # To show in right prompt:
@@ -251,13 +261,14 @@ add-zsh-hook precmd _scopeon_refresh
 
 fn fish_hook(exe: &str) -> String {
     let status_path = status_file_path();
-    let status_path_str = status_path.to_string_lossy();
+    let exe_q = shell_single_quote(exe);
+    let status_q = shell_single_quote(&status_path.to_string_lossy());
     format!(
         r#"# Scopeon ambient status — refresh $SCOPEON_STATUS on every prompt.
 # Source in config.fish via:  {exe} shell-hook --shell fish | source
 # Uses pre-written status file for zero-fork, zero-latency prompt updates.
 function _scopeon_refresh --on-event fish_prompt
-  set -gx SCOPEON_STATUS (cat "{status_path_str}" 2>/dev/null; or {exe} shell-status 2>/dev/null; or echo "")
+  set -gx SCOPEON_STATUS (cat {status_q} 2>/dev/null; or {exe_q} shell-status 2>/dev/null; or echo "")
 end
 # To show in prompt, add to fish_prompt:
 #   echo -n $SCOPEON_STATUS" "


### PR DESCRIPTION
## v0.8.0 Release

### Security
- Shell hook paths are now single-quote-escaped, preventing injection via paths with `$`, backticks, or spaces
- Git hook hardened with `set -eu` and a `case`-pattern trailer validator

### Performance
- DB writes batched per file in a single transaction — 100–1000× faster on large JSONL logs
- File offset committed atomically in the same transaction (crash-safe)
- TUI opens a read-only WAL connection, eliminating lock contention with the file watcher
- Dashboard uses `get_session_aggregates` instead of loading all turns into memory

### Fixed
- Providers tab now shows per-provider counts (was mixing all sessions under Claude Code)
- `CLAUDE_CONFIG_DIR` respected by `scopeon init`, `onboard`, and auto-detection
- Context pressure 'turns remaining' clamped to 10 000
- NaN/Inf/negative costs skipped in budget aggregation
- NaN panic in anomaly sort, u128→i64 truncation, Fish shell hook unquoted path

### Changed
- Docs reorganised: `ARCHITECTURE`, `CHANGELOG`, `CONTRIBUTING` → `docs/`; licenses → `docs/licenses/`; `CODE_OF_CONDUCT`, `SECURITY` → `.github/`

See [docs/changelog.md](docs/changelog.md) for full details.